### PR TITLE
Add options to include tlsOptions with ldapjs client

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This module is derived from the [hubot-auth](https://github.com/hubot-scripts/hu
 * `HUBOT_LDAP_AUTH_LDAP_URL` - the URL to the LDAP server
 * `HUBOT_LDAP_AUTH_BIND_DN` - the bind DN to authenticate with
 * `HUBOT_LDAP_AUTH_BIND_PASSWORD` - the bind password to authenticate with
+* `HUBOT_LDAP_AUTH_TLS_OPTIONS_CA` - the full path to a CA certificate file in PEM format. Passed to TLS connection layer when connecting via ldaps://
+* `HUBOT_LDAP_AUTH_TLS_OPTIONS_CERT` - the full path to a certificate file in PEM format. Passed to TLS connection layer when connecting via ldaps://
+* `HUBOT_LDAP_AUTH_TLS_OPTIONS_KEY` - the full path to a private key file in PEM format. Passed to TLS connection layer when connecting via ldaps://
+* `HUBOT_LDAP_AUTH_TLS_OPTIONS_CIPHERS` - cipher suite string. Passed to TLS connection layer when connecting via ldaps://
+* `HUBOT_LDAP_AUTH_TLS_OPTIONS_SECURE_PROTOCOL` - ssl method to use. Passed to TLS connection layer when connecting via ldaps://
 * `HUBOT_LDAP_AUTH_USER_SEARCH_FILTER` - the ldap filter search for a specific user - e.g. 'cn={0}' where '{0}' will be replaced by the hubot user attribute
 * `HUBOT_LDAP_AUTH_GROUP_MEMBERSHIP_ATTRIBUTE` - the member attribute within the user object
 * `HUBOT_LDAP_AUTH_GROUP_MEMBERSHIP_FILTER` - the membership filter to find groups based on user DN - e.g. 'member={0}' where '{0}' will be replaced by user DN


### PR DESCRIPTION
When creating the ldapjs client, I should be able to pass in additional TLS options (such as a custom CA, or modifying secureProtocol) which are used when creating a secure context.  The ldapjs client accepts the following:
```
Attribute: tlsOptions
Descrtiption: Additional options passed to TLS connection layer when connecting via ldaps:// (See: The TLS docs for node.js)
```
This PR adds new env variables for some of the more common settings (https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) which are passed into `tlsOptions` when creating the ldapjs client.  If there is another/better way of implementing this, I'm open to suggestions as well.  Thanks!





